### PR TITLE
Update emp client to 0.10.1

### DIFF
--- a/emp.rb
+++ b/emp.rb
@@ -1,9 +1,9 @@
 class Emp < Formula
   desc "CLI for Empire"
   homepage "https://github.com/remind101/empire"
-  url "https://github.com/remind101/empire/releases/download/v0.10.0/emp-Darwin-x86_64"
-  version "0.10.0"
-  sha256 "9c6959507e62baf18369180d91de70a6e09aeead5ef4a5eab22ab672a55051d9"
+  url "https://github.com/remind101/empire/releases/download/v0.10.1/emp-Darwin-x86_64"
+  version "0.10.1"
+  sha256 "23580df651606e6d45ac92818d6639438e1569025160e001b259144dd5735f3e"
 
   def install
     bin.install "emp-Darwin-x86_64" => "emp"


### PR DESCRIPTION
[v0.10.1](https://github.com/remind101/empire/releases/tag/v0.10.1) was released today.
